### PR TITLE
Add markdown saving command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ or
 adk web
 ```
 
-The agent will prompt you for your requirements and then guide you through the planning process, generating a comprehensive agent system design.
+The agent will prompt you for your requirements and then guide you through the planning process, generating a comprehensive agent system design. After the workflow completes, the final report is saved to `docs/agent_system_description.md`.
 
 ## Development
 

--- a/agents_planner/agent.py
+++ b/agents_planner/agent.py
@@ -4,12 +4,14 @@ This is the main agent that orchestrates the planning process.
 
 import typer
 from dotenv import load_dotenv
+from pathlib import Path
 from google.adk.agents.sequential_agent import SequentialAgent
 
 from .sub_agents.agent_designer.agent import agent_designer_agent
 from .sub_agents.final_description.agent import final_description_agent
 from .sub_agents.task_analyzer.agent import task_analyzer_agent
 from .sub_agents.workflow_designer.agent import workflow_designer_agent
+from .modules.constants import STATE_FINAL_DESCRIPTION, STATE_TASK
 
 load_dotenv()
 
@@ -25,3 +27,21 @@ planning_agents = SequentialAgent(
 )
 
 root_agent = planning_agents
+
+
+def run_and_save(task: str, file_path: str = "docs/agent_system_description.md"):
+    """Run the planning agents and save the final markdown report."""
+    state = {STATE_TASK: task}
+    result = planning_agents.run(state)
+    markdown = result.get(STATE_FINAL_DESCRIPTION)
+    if markdown:
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(markdown)
+    return result
+
+
+@app.command()
+def run(task: str, file_path: str = "docs/agent_system_description.md"):
+    """Run the agent planner and save the report to a markdown file."""
+    run_and_save(task, file_path)


### PR DESCRIPTION
## Summary
- add a helper to run the planner and write the final markdown report
- document that the final report is automatically saved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5f7bb0e4832ea10c8c821d17ef21